### PR TITLE
[bug-fix-feat-1664-CI] : fix e2e playwright testing

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -11,20 +11,24 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-
+      
+      # Print the current directory
       - name: Debugs logs
         run: pwd
 
+      # List curent directory
       - name: Debugs logs 2
         run: ls -l
 
       - name: Run interface test
         run: docker compose -f docker-compose.e2e.yml up --build --exit-code-from e2e
 
+      # If test fails, check the screenshot folder
       - name: Debugs logs 3
         if: failure()
         run: ls -l ./e2e/screenshots
 
+      # Upload screenshot in case of failure
       - name: Upload screenshot
         if: failure()
         uses: actions/upload-artifact@v4

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,53 +1,41 @@
+# to test this docker-compose locally and not wait for push on dev branch : docker compose -f docker-compose.e2e.yml up --build --exit-code-from e2e
+# to access Playwright report => go into e2e folder then run : npx playwright show-report
+
 services:
-  back:
-    build: 
-      context: ./backend
-      dockerfile: Dockerfile.deploy
-    healthcheck:
-      test: 'curl --fail --request POST --header ''content-type: application/json'' --url ''http://localhost:4000'' --data ''{"query":"query { __typename }"}'' || exit 1'
-      interval: 5s
-      timeout: 5s
-      retries: 10
-    ports:
-      - 4000:4000
-    environment:
-      CI: true
-      POSTGRES_USERNAME: postgres
-      POSTGRES_PASSWORD: example
-      JWT_SECRET: superSecret_secured____
-    depends_on:
-      db:
-        condition: service_healthy
   front:
-    build: 
-      context: ./frontend
-      dockerfile: Dockerfile.deploy
+    build: ./frontend
+    restart: unless-stopped
     healthcheck:
-      test: "curl --fail --request GET --url 'http://localhost:3000' || exit 1"
-      interval: 5s
-      timeout: 5s
-      retries: 10
-    depends_on:
-      back:
-        condition: service_healthy
-  db:
-    image: postgres
-    environment:
-      POSTGRES_PASSWORD: example
-      POSTGRES_DB: the_good_corner
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d postgres -U postgres"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 10s
       timeout: 5s
-      retries: 20
-  e2e:
-    build: ./e2e
-    environment:
-      CI: true
+      retries: 3
+    ports:
+      - "3001:3000" # External port 3001 so no conflicts with the port 3000 already running in main docker-compose.yml in client service
+    command: npm run dev
     volumes:
-      - ./e2e/playwright-report:/app/playwright-report
-      - ./e2e/test-results:/app/test-results
-      - ./e2e/screenshots:/app/screenshots
+      - ./frontend/src:/app/src
+      - ./frontend/public:/app/public
+      - ./frontend/package.json:/app/package.json
+      - ./frontend/vite.config.ts:/app/vite.config.ts
+      - ./frontend/index.html:/app/index.html
+      - ./frontend/codegen.ts:/app/codegen.ts
+    environment:
+      WDS_SOCKET: 127.0.0.1
+      CHOKIDAR_USEPOLLING: true
+      WATCHPACK_POLLING: true
+
+  e2e:
+    image: mcr.microsoft.com/playwright:v1.49.1-noble
+    working_dir: /tests
+    volumes:
+      - ./e2e:/tests
     depends_on:
-      front:
-        condition: service_healthy
+      - front
+    ports:
+      - "9323:9323" # port localhost:9323 for Playwright report
+    command: >
+      sh -c "
+      echo 'Running Playwright e2e tests...' &&
+      npx playwright test
+      "

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,16 @@
+# must match package json version
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+RUN npx playwright install
+
+COPY playwright.config.ts /app/playwright.config.ts
+
+COPY tests/ /app/tests/
+
+CMD ["npx", "playwright", "test"]

--- a/e2e/tests/example.spec.ts
+++ b/e2e/tests/example.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
+const url = "http://front:3000";
 test("has title", async ({ page }) => {
-  await page.goto("http://localhost:3000/");
+  await page.goto(url);   // Go to http://front:3000/ and not localhost (voir service front dans docker-compose.e2e.yml)
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/PulseForm/);

--- a/frontend/11.0.0
+++ b/frontend/11.0.0
@@ -1,0 +1,4 @@
+Unknown command: "notice"
+
+To see a list of supported npm commands, run:
+  npm help

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@biomejs/biome": "1.9.4",
         "@graphql-codegen/cli": "^5.0.2",
         "@graphql-codegen/client-preset": "^4.3.3",
+        "@playwright/test": "^1.49.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/react": "^16.0.1",
@@ -3076,6 +3077,21 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -7243,6 +7259,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "generate": "graphql-codegen",
     "lint": "npx @biomejs/biome lint ./ ",
     "format": "npx @biomejs/biome format ./ --write",
-    "test": "vitest --coverage"
+    "test": "vitest --coverage",
+    "test:e2e": "npx playwright test"
   },
   "dependencies": {
     "@apollo/client": "^3.11.8",
@@ -32,6 +33,7 @@
     "@biomejs/biome": "1.9.4",
     "@graphql-codegen/cli": "^5.0.2",
     "@graphql-codegen/client-preset": "^4.3.3",
+    "@playwright/test": "^1.49.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.2",
     "@testing-library/react": "^16.0.1",


### PR DESCRIPTION
Les jobs du fichier `e2e_tests.yml` dans .github/workflows ont échoué lors du dernier push sur la branche `dev`.
Correction du `docker-compose.e2e.yml` 

Désormais les tests Playwrights et jobs e2e sont opérationnels.

Pour lancer les tests e2e en local sans attendre le push sur dev pour voir si les tests fail (c'était mon erreur ;) ) : se placer à la racine du projet et  lancer `docker compose -f docker-compose.e2e.yml up --build --exit-code-from e2e`

Accès au rapport Playwright : se placer dans le dossier e2e et  lancer `npx playwright show-report`

![image](https://github.com/user-attachments/assets/13b2e93f-571d-4611-b169-1db9bc1480e8)
